### PR TITLE
Added audio and video elements to focusableElementsString

### DIFF
--- a/px-modal.html
+++ b/px-modal.html
@@ -343,7 +343,7 @@ Custom property | Description
        * @return {Array.<HTMLElement>}
        */
       _getFocusableElements() {
-        const focusableElementsString = 'a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), iframe, object, embed, [tabindex="0"], [contenteditable]';
+        const focusableElementsString = 'a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), iframe, object, embed, [tabindex="0"], [contenteditable], audio[controls], video[controls]';
         let focusableSlottedElements = Polymer.dom(this).querySelectorAll('button') || [];
         if (focusableSlottedElements instanceof NodeList) {
           focusableSlottedElements = Array.prototype.slice.call(focusableSlottedElements);


### PR DESCRIPTION
I guess the initial `focusableElementsString` was taken from https://github.com/jkup/focusable

This PR syncs it with the recent update: https://github.com/jkup/focusable/commit/69db8a998f825b1cf0277449e5627777d0a07016 and allows `audio` and `video` elements with controls to be focusable.